### PR TITLE
Minor error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Join to our telegram group @darktunnel_group or click [here](https://t.me/darktu
 Install
 -------
 
-	go get -v github.com/aztecrabbit/bugscanner-go
+	go install -v github.com/aztecrabbit/bugscanner-go@latest
 
 
 #### Add go bin to PATH


### PR DESCRIPTION
C:\Users\Apih>go get -v github.com/aztecrabbit/bugscanner-go
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

so i fix this 